### PR TITLE
Feature/add sudo comment

### DIFF
--- a/chromeExtension/manifest.json
+++ b/chromeExtension/manifest.json
@@ -28,7 +28,6 @@
   "content_security_policy": "script-src 'self' https://connect.facebook.net; object-src 'self'",
   "content_scripts": [{
     "matches": [
-      "https://www.sudo.com.tw/",
       "https://www.sudo.com.tw/companies/*",
       "https://www.104.com.tw/job/*",
       "http://www.104.com.tw/job/*",

--- a/chromeExtension/manifest.json
+++ b/chromeExtension/manifest.json
@@ -28,6 +28,7 @@
   "content_security_policy": "script-src 'self' https://connect.facebook.net; object-src 'self'",
   "content_scripts": [{
     "matches": [
+      "https://www.sudo.com.tw/companies/*",
       "https://www.104.com.tw/job/*",
       "http://www.104.com.tw/job/*",
       "http://www.1111.com.tw/job-bank/job-description*"

--- a/chromeExtension/manifest.json
+++ b/chromeExtension/manifest.json
@@ -28,7 +28,7 @@
   "content_security_policy": "script-src 'self' https://connect.facebook.net; object-src 'self'",
   "content_scripts": [{
     "matches": [
-      "https://www.sudo.com.tw/companies/*",
+      "https://sudo.com.tw/companies/*",
       "https://www.104.com.tw/job/*",
       "http://www.104.com.tw/job/*",
       "http://www.1111.com.tw/job-bank/job-description*"

--- a/chromeExtension/manifest.json
+++ b/chromeExtension/manifest.json
@@ -28,6 +28,7 @@
   "content_security_policy": "script-src 'self' https://connect.facebook.net; object-src 'self'",
   "content_scripts": [{
     "matches": [
+      "https://www.sudo.com.tw/",
       "https://www.sudo.com.tw/companies/*",
       "https://www.104.com.tw/job/*",
       "http://www.104.com.tw/job/*",

--- a/front-end/app/providers/index.js
+++ b/front-end/app/providers/index.js
@@ -5,7 +5,7 @@ import sudo  from './sudo.js'
 const rootProvider = {
     ["104"]: p104,
     ["1111"]: p1111,
-    ["sudo"]: sudo,
+    ["sudo"]: sudo
 }
 
 export function getProviderName() {

--- a/front-end/app/providers/index.js
+++ b/front-end/app/providers/index.js
@@ -1,5 +1,6 @@
-import p104 from './104.js'
+import p104  from './104.js'
 import p1111 from './1111.js'
+import sudo  from './sudo.js'
 
 const rootProvider = {
     ["104"]: p104,

--- a/front-end/app/providers/index.js
+++ b/front-end/app/providers/index.js
@@ -4,7 +4,8 @@ import sudo  from './sudo.js'
 
 const rootProvider = {
     ["104"]: p104,
-    ["1111"]: p1111
+    ["1111"]: p1111,
+    ["sudo"]: sudo,
 }
 
 export function getProviderName() {

--- a/front-end/app/providers/sudo.js
+++ b/front-end/app/providers/sudo.js
@@ -1,18 +1,24 @@
-/**
- * [getCompanyName] get sudo company name with dumb way
- * @return {[string]} 
- */
-function getCompanyName() {
+function get_company_name() {
 	return document.querySelector('h1.header').innerText || null;
 }
 
-function getJobName() {
+function get_job_name() {
 	return document.querySelector('h1').innerText || "";
 }
 
+function get_sudo_job_no() {
+	if(location.pathname.includes('jobs')) {
+	  pathNameArr = location.pathname.split('/');
+		return pathNameArr[pathNameArr.length - 1];
+	} else {
+		return null;
+	}
+}
+
 const provider = {
-  getCompanyName,
-  getJobName
+  get_company_name,
+  get_job_name,
+  get_sudo_job_no
 }
 
 export default provider

--- a/front-end/app/providers/sudo.js
+++ b/front-end/app/providers/sudo.js
@@ -3,12 +3,16 @@
  * @return {[string]} 
  */
 function getCompanyName() {
-	return document.querySelector("h1.header").innerText() || null;
+	return document.querySelector('h1.header').innerText || null;
 }
 
+function getJobName() {
+	return document.querySelector('h1').innerText || "";
+}
 
 const provider = {
-  getCompanyName
+  getCompanyName,
+  getJobName
 }
 
 export default provider

--- a/front-end/app/providers/sudo.js
+++ b/front-end/app/providers/sudo.js
@@ -1,0 +1,14 @@
+/**
+ * [getCompanyName] get sudo company name with dumb way
+ * @return {[string]} 
+ */
+function getCompanyName() {
+	return document.querySelector("h1.header").innerText() || null;
+}
+
+
+const provider = {
+  getCompanyName
+}
+
+export default provider

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.5.0",
     "babel-register": "^6.9.0",
+    "babel-runtime": "^6.9.2",
     "chai": "^3.5.0",
     "cross-env": "^1.0.7",
     "css-loader": "^0.23.1",


### PR DESCRIPTION
哈囉丹尼，好久不見XD
## 這隻 pull request 做了什麼？
1. 加入 sudo 公司頁面留言功能（目前只有實作公司頁面） #16 
2. 加入 `sudo provider`
### reference
1. `providers/sudo.js`
2. `manifest.js`
## Testing Guide
- 到 sudo 任一公司頁面，確認 chrome extension 是否有正確顯示。

<img width="1278" alt="2016-06-14 2 26 17" src="https://cloud.githubusercontent.com/assets/6581081/16018536/722ad010-31d7-11e6-88f4-c8b4f7ca6faa.png">
## FYI

另外 [sudo](https://www.sudo.com.tw) 也已經有實作面試評論的功能，只要是從 sudo 上申請職缺，並透過線上安排面試的面試者，都可以到該公司頁面進行評價，目的是希望讓求職者能夠更了解公司文化，資訊的傳遞能夠更透明。有興趣的求職者可以試用看看！

<img width="640" alt="2016-06-14 2 30 53" src="https://cloud.githubusercontent.com/assets/6581081/16018689/1f1eb926-31d8-11e6-8ad2-0844ade89b20.png">
<img width="1223" alt="2016-06-14 2 31 19" src="https://cloud.githubusercontent.com/assets/6581081/16018688/1f1e4c84-31d8-11e6-9122-6857dbed14d8.png">
