### PR TITLE
fix(canonical): fix 1111 canonical URL

### DIFF
--- a/chromeExtension/manifest.json
+++ b/chromeExtension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Clairvoyance - 求職天眼通",
   "description": "讓你能在各大人力銀行上留言討論職缺，減少求職的資訊不對稱",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "author": "clver",
   "icons": {
     "16": "icon16.png",
@@ -32,6 +32,7 @@
       "http://www.104.com.tw/job/*",
       "http://104.com.tw/job/*",
       "https://104.com.tw/job/*",
+      "http://www.1111.com.tw//job-bank/job-description*",
       "http://www.1111.com.tw/job-bank/job-description*"
     ],
     "js": [

--- a/firefoxExtension/manifest.json
+++ b/firefoxExtension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Clairvoyance - 求職天眼通",
   "description": "讓你能在各大人力銀行上留言討論職缺，減少求職的資訊不對稱",
-  "version": "3.0",
+  "version": "3.1.3",
   "author": "clver",
   "icons": {
     "16": "icon16.png",
@@ -37,6 +37,9 @@
     "matches": [
       "https://www.104.com.tw/job/*",
       "http://www.104.com.tw/job/*",
+      "http://104.com.tw/job/*",
+      "https://104.com.tw/job/*",
+      "http://www.1111.com.tw//job-bank/job-description*",
       "http://www.1111.com.tw/job-bank/job-description*"
     ],
     "js": [


### PR DESCRIPTION
解決1111的canonical URL有兩個連續斜線造成disqus留言連結沒有天眼通區塊的問題。
在`manifest.json`的`content_scripts.matches`新增`"http://www.1111.com.tw//job-bank/job-description*"`